### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,8 @@ Copyright 2021 Alexander Fisher
 ## Transfer Notice
 
 This plugin was originally authored by [Alexander Fisher](https://github.com/alexjfisher).
-The maintainer preferred that Puppet Community take ownership of the module for future improvement and maintenance.
-Existing pull requests and issues were transferred over, please fork and continue to contribute here instead of Camptocamp.
-
-Previously: https://github.com/alexjfisher/puppet-lint-optional_default-check
+The maintainer preferred that [Vox Pupuli](https://voxpupuli.org/) take ownership of the module for future improvement and maintenance.
+Existing pull requests and issues were transferred, please fork and continue to contribute [here](https://github.com/voxpupuli/puppet-lint-optional_default-check) instead of on Alex's [fork](https://github.com/alexjfisher/puppet-lint-optional_default-check).
 
 ## License
 
@@ -103,4 +101,4 @@ To make a new release, please do:
 * Install gems with `bundle install --with release --path .vendor`
 * generate the changelog with `bundle exec rake changelog`
 * Create a PR with it
-* After it got merged, push a tag. Travis will do the actual release
+* After it got merged, push a tag. A github workflow will do the actual release


### PR DESCRIPTION
I'm not Camptocamp. :)

The original wording didn't mention Vox, but Puppet Community which is
Vox's original name.

Also, `here` didn't make any sense to anybody who stumbles across my new
fork (needed to open this PR).