### PR TITLE
(MAINT) Bump Puppet Lint requirement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
-          - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
             coverage: "yes"

--- a/puppet-lint-optional_default-check.gemspec
+++ b/puppet-lint-optional_default-check.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check that Optional class/defined type parameters don't default to anything other than `undef`.
   EOF
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency             'puppet-lint', '>= 2.1', '< 3.0'
+  spec.add_dependency             'puppet-lint', '~> 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
`puppet-lint` v3.0 has now been released. This gem specified support for versions less than 3.

This PR bumps the lint requirement to "~> 3.0" and Ruby to 2.7.