### PR TITLE
Use new puppet-lint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group :development do
   gem 'rspec-collection_matchers', '~> 1.2'
   gem 'rspec-its', '~> 1.3'
   gem 'voxpupuli-rubocop', '~> 2.0'
+  gem 'puppetlabs-lint', github: 'puppetlabs/puppet-lint', branch: 'fix-namespace-clash'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ group :coverage, optional: ENV['COVERAGE'] != 'yes' do
 end
 
 group :development do
+  gem 'puppetlabs-lint', github: 'puppetlabs/puppet-lint', branch: 'fix-namespace-clash'
   gem 'rake', '~> 13.0', '>= 13.0.6'
   gem 'rspec', '~> 3.12'
   gem 'rspec-collection_matchers', '~> 1.2'
   gem 'rspec-its', '~> 1.3'
   gem 'voxpupuli-rubocop', '~> 2.0'
-  gem 'puppetlabs-lint', github: 'puppetlabs/puppet-lint', branch: 'fix-namespace-clash'
 end

--- a/puppet-lint-optional_default-check.gemspec
+++ b/puppet-lint-optional_default-check.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'puppet-lint', '>= 3', '< 5'
+  spec.add_dependency 'puppetlabs-puppet-lint', '~> 5.0'
 end

--- a/puppet-lint-optional_default-check.gemspec
+++ b/puppet-lint-optional_default-check.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'puppetlabs-lint', '~> 5.0'
+  # spec.add_dependency 'puppet-lint', '>= 3', '< 5'
 end

--- a/puppet-lint-optional_default-check.gemspec
+++ b/puppet-lint-optional_default-check.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'puppetlabs-puppet-lint', '~> 5.0'
+  spec.add_dependency 'puppetlabs-lint', '~> 5.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,6 @@ else
   ]
 end
 
-require 'puppet-lint'
+require 'puppetlabs-lint'
 
 PuppetLint::Plugins.load_spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,6 @@ else
   ]
 end
 
-require 'puppetlabs-lint'
+require 'puppetlabs/puppetlabs-lint'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
Using the now-maintained puppetlabs-puppet-lint over puppet-lint